### PR TITLE
Localize hard-coded UI strings

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,7 +3,7 @@
     <NcAppNavigation>
       <template id="app-nextpod-navigation" #list>
         <!--				<NcAppNavigationItem to="/actions" :to="{name: 'episodes'}" title="Episodes">-->
-        <NcAppNavigationItem to="/actions" name="Episodes">
+        <NcAppNavigationItem to="/actions" :name="t('nextpod', 'Episodes')">
           <template #icon>
             <FileMusic :size="20" />
           </template>
@@ -14,7 +14,7 @@
           </template>
         </NcAppNavigationItem>
         <!--				<NcAppNavigationItem to="/podcasts" :to="{name: 'podcasts'}" title="Podcasts">-->
-        <NcAppNavigationItem to="/podcasts" name="Podcasts">
+        <NcAppNavigationItem to="/podcasts" :name="t('nextpod', 'Podcasts')">
           <template #icon>
             <Podcast :size="20" />
           </template>

--- a/src/components/ActionListItem.vue
+++ b/src/components/ActionListItem.vue
@@ -22,7 +22,9 @@
           />
         </template>
         <template #subname>
-          <span v-if="isLoading"><em>(Loading RSS data...)</em></span>
+          <span v-if="isLoading">
+            <em>{{ t("nextpod", "(Loading RSS data...)") }}</em>
+          </span>
           <span v-else>{{ getPodcastName() }}</span>
         </template>
         <template #actions>
@@ -34,13 +36,13 @@
             <template #icon>
               <OpenInNew :size="20" />
             </template>
-            Open episode link
+            {{ t("nextpod", "Open episode link") }}
           </NcActionLink>
           <NcActionButton @click.stop="showModalPlayer">
             <template #icon>
               <Play :size="20" />
             </template>
-            Play episode media
+            {{ t("nextpod", "Play episode media") }}
           </NcActionButton>
           <NcActionButton
             v-if="!isLoading && hasNotesApp"
@@ -49,19 +51,19 @@
             <template #icon>
               <FileDocument :size="20" />
             </template>
-            Create note of episode
+            {{ t("nextpod", "Create note of episode") }}
           </NcActionButton>
           <NcActionLink :href="action.episodeUrl" target="_blank">
             <template #icon>
               <Download :size="20" />
             </template>
-            Download episode media
+            {{ t("nextpod", "Download episode media") }}
           </NcActionLink>
           <NcActionLink :href="action.podcastUrl" target="_blank">
             <template #icon>
               <Rss :size="20" />
             </template>
-            Open RSS feed
+            {{ t("nextpod", "Open RSS feed") }}
           </NcActionLink>
         </template>
       </NcListItem>
@@ -73,8 +75,14 @@
       :outTransition="true"
     >
       <div class="modal__content">
-        <h2 v-if="isLoading">Playing episode</h2>
-        <h2 v-else>Playing "{{ getEpisodeName() }}"</h2>
+        <h2 v-if="isLoading">{{ t("nextpod", "Playing episode") }}</h2>
+        <h2 v-else>
+          {{
+            t("nextpod", 'Playing "{episode}"', {
+              episode: getEpisodeName(),
+            })
+          }}
+        </h2>
         <audio
           controls
           autoplay
@@ -83,7 +91,9 @@
           @timeupdate="onTimeUpdateListener"
         >
           <source :src="action.episodeUrl" />
-          Your browser does not support the audio element.
+          {{
+            t("nextpod", "Your browser does not support the audio element.")
+          }}
         </audio>
         <p>
           <input
@@ -92,7 +102,9 @@
             class="checkbox"
             v-model="storePlayProgress"
           />
-          <label for="store-play-progress">Store progress while playing</label>
+          <label for="store-play-progress">
+            {{ t("nextpod", "Store progress while playing") }}
+          </label>
         </p>
       </div>
     </NcModal>
@@ -103,8 +115,10 @@
       :outTransition="true"
     >
       <div class="modal__content description-content">
-        <h2 v-if="isLoading">Loading episode description...</h2>
-        <h2 v-else v-html="getEpisodeName()">Episode description</h2>
+        <h2 v-if="isLoading">
+          {{ t("nextpod", "Loading episode description...") }}
+        </h2>
+        <h2 v-else v-html="getEpisodeName()" />
         <h3 v-html="getPodcastName()"></h3>
         <div v-html="getEpisodeDescription()"></div>
       </div>
@@ -129,6 +143,7 @@ import Rss from "vue-material-design-icons/Rss.vue";
 import TurndownService from "turndown";
 
 import { generateUrl } from "@nextcloud/router";
+import { translate as t } from "@nextcloud/l10n";
 import axios from "@nextcloud/axios";
 
 export default {
@@ -265,9 +280,15 @@ export default {
       const modMinutes = Math.floor(seconds / 60) % 60;
       if (hours === 0) {
         const modSeconds = seconds % 60;
-        return `${modMinutes}min ${modSeconds}s`;
+        return t("nextpod", "{minutes}min {seconds}s", {
+          minutes: modMinutes,
+          seconds: modSeconds,
+        });
       }
-      return `${hours}h ${modMinutes}min`;
+      return t("nextpod", "{hours}h {minutes}min", {
+        hours,
+        minutes: modMinutes,
+      });
     },
     getDetails() {
       if (this.action.position === -1 || this.action.total === -1) {
@@ -275,14 +296,19 @@ export default {
       }
 
       if (this.action.position === this.action.total) {
-        return `(done, ${this.getTimeString(this.action.total)})`;
+        return t("nextpod", "(done, {duration})", {
+          duration: this.getTimeString(this.action.total),
+        });
       }
 
       const percent = Math.round(
         (this.action.position / this.action.total) * 100,
       );
 
-      return `(${percent}% of ${this.getTimeString(this.action.total)} listened)`;
+      return t("nextpod", "({percent}% of {duration} listened)", {
+        percent,
+        duration: this.getTimeString(this.action.total),
+      });
     },
     getImageSrc() {
       return this.actionExtraData?.episodeImage ?? "";

--- a/src/components/ActionListItem.vue
+++ b/src/components/ActionListItem.vue
@@ -78,9 +78,14 @@
         <h2 v-if="isLoading">{{ t("nextpod", "Playing episode") }}</h2>
         <h2 v-else>
           {{
-            t("nextpod", 'Playing "{episode}"', {
-              episode: getEpisodeName(),
-            })
+            t(
+              "nextpod",
+              'Playing "{episode}"',
+              {
+                episode: getEpisodeName(),
+              },
+              { escape: false },
+            )
           }}
         </h2>
         <audio
@@ -91,9 +96,7 @@
           @timeupdate="onTimeUpdateListener"
         >
           <source :src="action.episodeUrl" />
-          {{
-            t("nextpod", "Your browser does not support the audio element.")
-          }}
+          {{ t("nextpod", "Your browser does not support the audio element.") }}
         </audio>
         <p>
           <input

--- a/src/components/SubscriptionListItem.vue
+++ b/src/components/SubscriptionListItem.vue
@@ -12,7 +12,9 @@
       />
     </template>
     <template #subname>
-      <span v-if="isLoading"><em>(Loading RSS data...)</em></span>
+      <span v-if="isLoading">
+        <em>{{ t("nextpod", "(Loading RSS data...)") }}</em>
+      </span>
       <span v-else>{{ getSubtitle() }}</span>
     </template>
     <template #actions>
@@ -24,13 +26,13 @@
         <template #icon>
           <OpenInNew :size="20" />
         </template>
-        Podcast's homepage
+        {{ t("nextpod", "Podcast's homepage") }}
       </NcActionLink>
       <NcActionLink :href="getRssLink()" target="_blank">
         <template #icon>
           <Rss :size="20" />
         </template>
-        RSS feed
+        {{ t("nextpod", "RSS feed") }}
       </NcActionLink>
     </template>
   </NcListItem>
@@ -43,6 +45,7 @@ import Rss from "vue-material-design-icons/Rss.vue";
 import OpenInNew from "vue-material-design-icons/OpenInNew.vue";
 
 import { generateUrl } from "@nextcloud/router";
+import { translate as t } from "@nextcloud/l10n";
 import axios from "@nextcloud/axios";
 
 export default {
@@ -92,16 +95,22 @@ export default {
     },
     getDetails() {
       if (this.sub.listenedSeconds <= 0) {
-        return "(no time listened)";
+        return t("nextpod", "(no time listened)");
       }
       const seconds = this.sub.listenedSeconds;
       const hours = Math.floor(seconds / 3600);
       const modMinutes = Math.floor(seconds / 60) % 60;
       if (hours === 0) {
         const modSeconds = seconds % 60;
-        return `(${modMinutes}min ${modSeconds}s listened)`;
+        return t("nextpod", "({minutes}min {seconds}s listened)", {
+          minutes: modMinutes,
+          seconds: modSeconds,
+        });
       }
-      return `(${hours}h ${modMinutes}min listened)`;
+      return t("nextpod", "({hours}h {minutes}min listened)", {
+        hours,
+        minutes: modMinutes,
+      });
     },
     getImageSrc() {
       return this.podcastData?.imageBlob ?? this.podcastData?.imageUrl ?? "";

--- a/src/views/Actions.vue
+++ b/src/views/Actions.vue
@@ -18,7 +18,9 @@
 
     <div v-if="actions.length > 0" class="actions">
       <div class="sorting-container">
-        <label for="nextpod_action_filtering">Action:</label>
+        <label for="nextpod_action_filtering">
+          {{ t("nextpod", "Action:") }}
+        </label>
         <NcMultiselect
           id="nextpod_action_filtering"
           v-model="actionFilter"
@@ -55,11 +57,21 @@
           <Podcast />
         </template>
         <template #title>
-          <h1>No episode actions</h1>
-          Start syncing podcasts from your favorite podcast client, such as
-          <a class="link" href="https://antennapod.org/" target="_blank"
-            >Antennapod</a
-          >, and then refresh this page to see them pop up here.
+          <h1>{{ t("nextpod", "No episode actions") }}</h1>
+          {{
+            t(
+              "nextpod",
+              "Start syncing podcasts from your favorite podcast client, such as",
+            )
+          }}
+          <a class="link" href="https://antennapod.org/" target="_blank">
+            AntennaPod</a
+          >{{
+            t(
+              "nextpod",
+              ", and then refresh this page to see them pop up here.",
+            )
+          }}
         </template>
       </NcEmptyContent>
     </div>
@@ -81,15 +93,11 @@ import Podcast from "vue-material-design-icons/Podcast";
 import PageNext from "vue-material-design-icons/PageNext.vue";
 
 import { generateUrl } from "@nextcloud/router";
+import { translate as t } from "@nextcloud/l10n";
 import axios from "@nextcloud/axios";
 import { showError } from "@nextcloud/dialogs";
 import HeaderNavigation from "./HeaderNavigation.vue";
 import { loadState } from "@nextcloud/initial-state";
-
-const actionFilteringOptions = [
-  { label: "Play", action: "PLAY" },
-  { label: "Download", action: "DOWNLOAD" },
-];
 
 export default {
   name: "Actions",
@@ -106,6 +114,11 @@ export default {
     NcActions,
   },
   data() {
+    const actionFilteringOptions = [
+      { label: t("nextpod", "Play"), action: "PLAY" },
+      { label: t("nextpod", "Download"), action: "DOWNLOAD" },
+    ];
+
     return {
       allActions: [],
       actions: [],

--- a/src/views/HeaderNavigation.vue
+++ b/src/views/HeaderNavigation.vue
@@ -24,6 +24,7 @@
 
 <script>
 import { NcButton, NcLoadingIcon } from "@nextcloud/vue";
+import { translate as t } from "@nextcloud/l10n";
 
 export default {
   name: "HeaderNavigation",
@@ -50,7 +51,7 @@ export default {
     },
     rootTitle: {
       type: String,
-      default: t("nextpodsyn", "Podcasts"),
+      default: t("nextpod", "Podcasts"),
     },
     // The route params
     params: {

--- a/src/views/Podcasts.vue
+++ b/src/views/Podcasts.vue
@@ -17,7 +17,9 @@
     </HeaderNavigation>
     <div v-if="subscriptions.length > 0" class="podcasts">
       <div class="sorting-container">
-        <label for="nextpod_sorting">Sort by:</label>
+        <label for="nextpod_sorting">
+          {{ t("nextpod", "Sort by:") }}
+        </label>
         <NcMultiselect
           id="nextpod_sorting"
           v-model="sortBy"
@@ -42,11 +44,21 @@
           <Podcast />
         </template>
         <template #title>
-          <h1>No subscriptions</h1>
-          Start syncing podcasts from your favorite podcast client, such as
-          <a class="link" href="https://antennapod.org/" target="_blank"
-            >Antennapod</a
-          >, and then refresh this page to see them pop up here.
+          <h1>{{ t("nextpod", "No subscriptions") }}</h1>
+          {{
+            t(
+              "nextpod",
+              "Start syncing podcasts from your favorite podcast client, such as",
+            )
+          }}
+          <a class="link" href="https://antennapod.org/" target="_blank">
+            AntennaPod</a
+          >{{
+            t(
+              "nextpod",
+              ", and then refresh this page to see them pop up here.",
+            )
+          }}
         </template>
       </NcEmptyContent>
     </div>
@@ -68,20 +80,10 @@ import Podcast from "vue-material-design-icons/Podcast";
 import PageNext from "vue-material-design-icons/PageNext.vue";
 
 import { generateUrl } from "@nextcloud/router";
+import { translate as t } from "@nextcloud/l10n";
 import axios from "@nextcloud/axios";
 import { showError } from "@nextcloud/dialogs";
 import HeaderNavigation from "./HeaderNavigation.vue";
-
-const sortingOptions = [
-  {
-    label: "Listened time (desc)",
-    compare: (a, b) => a?.listenedSeconds < b?.listenedSeconds,
-  },
-  {
-    label: "Listened time (asc)",
-    compare: (a, b) => a?.listenedSeconds > b?.listenedSeconds,
-  },
-];
 
 export default {
   name: "Podcasts",
@@ -98,6 +100,17 @@ export default {
     NcActions,
   },
   data() {
+    const sortingOptions = [
+      {
+        label: t("nextpod", "Listened time (desc)"),
+        compare: (a, b) => a?.listenedSeconds < b?.listenedSeconds,
+      },
+      {
+        label: t("nextpod", "Listened time (asc)"),
+        compare: (a, b) => a?.listenedSeconds > b?.listenedSeconds,
+      },
+    ];
+
     return {
       subscriptions: [],
       isLoading: true,


### PR DESCRIPTION
## Summary
- Wrap hard-coded NextPod UI strings with `t("nextpod", ...)` for l10n.
- Fix HeaderNavigation fallback translation domain typo (`nextpodsyn` → `nextpod`).

Fixes #8

## Test plan
- [x] `npm run build`
- [x] `npx eslint src`
- [ ] Spot-check UI strings still render; confirm they appear in translation extraction.
